### PR TITLE
Cassette content mix bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nock-utils",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Utility tools to simplify recording and playing back http requests during tests",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/recorder/HttpRecorder.ts
+++ b/src/recorder/HttpRecorder.ts
@@ -69,6 +69,7 @@ export class HttpRecorder {
     const calls = nock.recorder.play();
 
     jsonfile.writeFileSync(this.path, calls, WRITE_OPTIONS);
+    nock.recorder.clear();
   }
 
   isCassetteLoaded(): boolean {

--- a/src/recorder/__tests__/HttpRecorder.test.ts
+++ b/src/recorder/__tests__/HttpRecorder.test.ts
@@ -7,8 +7,10 @@ import * as express from 'express';
 const app = express()
 
 const TEST_CASSETTE = `${__dirname}/test_cassette.json`;
+const TEST_CASSETTE_DUPLICATE = `${__dirname}/test_cassette_duplicate.json`;
 const TEST_URL = 'http://127.0.0.1:3000';
 const TEST_RESULT = 'result_ok';
+const MAX_DUPLICATE_FILE_SIZE = 500;
 
 function startServer() {
   app.get('/', (req, res) => res.send(TEST_RESULT))
@@ -120,5 +122,37 @@ describe('HttpRecorder', () => {
     
     const testCassette = JSON.parse(fs.readFileSync(TEST_CASSETTE, 'utf8'));
     expect(testCassette[0].response).to.equal(TEST_RESULT);
+  });
+});
+
+describe('Restrict Content by File', () => {
+  before(() => {
+    server = startServer();
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(TEST_CASSETTE_DUPLICATE)) {
+      fs.unlinkSync(TEST_CASSETTE_DUPLICATE);
+    }
+  });
+  
+  it('should create a file and write content without previous tests', async () => {
+    let fileExistsInitial = fs.existsSync(TEST_CASSETTE_DUPLICATE);
+    expect(fileExistsInitial).to.be.false;
+
+    const recorder = new HttpRecorder(TEST_CASSETTE_DUPLICATE);
+    recorder.start();
+    const result = await rest(TEST_URL);
+    recorder.stop();
+
+    let fileExists = fs.existsSync(TEST_CASSETTE_DUPLICATE);
+    expect(fileExists).to.be.true;
+
+    const cassetteStats = fs.statSync(TEST_CASSETTE_DUPLICATE);
+    expect(cassetteStats.size).lt(MAX_DUPLICATE_FILE_SIZE);
   });
 });

--- a/src/recorder/__tests__/HttpRecorder.test.ts
+++ b/src/recorder/__tests__/HttpRecorder.test.ts
@@ -140,17 +140,16 @@ describe('Restrict Content by File', () => {
     }
   });
   
-  it('should create a file and write content without previous tests', async () => {
+  it('should validate the test cassette does not exist', async () => {
     let fileExistsInitial = fs.existsSync(TEST_CASSETTE_DUPLICATE);
     expect(fileExistsInitial).to.be.false;
+  });
 
+  it('should create a file and write content without previous tests', async () => {
     const recorder = new HttpRecorder(TEST_CASSETTE_DUPLICATE);
     recorder.start();
     const result = await rest(TEST_URL);
     recorder.stop();
-
-    let fileExists = fs.existsSync(TEST_CASSETTE_DUPLICATE);
-    expect(fileExists).to.be.true;
 
     const cassetteStats = fs.statSync(TEST_CASSETTE_DUPLICATE);
     expect(cassetteStats.size).lt(MAX_DUPLICATE_FILE_SIZE);


### PR DESCRIPTION
When multiple cassettes where recorded, the content was being recorded from the beginning of all tests. This fix cleans nocks recorder cache when stopping to start a clean cassette on start.