### PR TITLE
Added ignored scopes to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ rest('https://www.comparaonline.com').then((result) => {
 });
 ```
 
+## Ignoring certain urls
+
+In some cases maybe it's necessary to ignore some request recording, for example, socket.io functionalities.
+
+### Example
+
+```
+const nockUtils = require('nock-utils');
+const ignoredScopes = ['http://mysocketio.connection.local'];
+const recorder = new nockUtils.HttpRecorder('cassette.json', ignoredScopes);
+recorder.start();
+
+# Call http requests here, the ignored scopes will be omitted from writing.
+
+recorder.stop();
+```
+
+
+
 ## Installation
 
 With npm:


### PR DESCRIPTION
## Purpose

When doing tests for socket.io connections we have problems with the cassettes, because the socket.io connections was recorded. This broke our test and we manually remove the socket.io requests.

So we need a feature to allow us to ignore recording for some urls. 

## Solving Aproach

We added a hosts list to be omitted from recording.