### PR TITLE
Check all mocks are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,35 +3,35 @@ Utility tools to simplify recording and playing back http requests during tests
 
 ## Quick Example
 
-```
+```javascript
 const nockUtils = require('nock-utils');
 const recorder = new nockUtils.HttpRecorder('cassette.json');
 recorder.start();
 
-# Call http requests here.
+// Call http requests here.
 
 recorder.stop();
 ```
 
 ## Complete Example
-```
-# Import nock-utils
+```javascript
+// Import nock-utils
 const nockUtils = require('nock-utils');
 const rest = require('rest');
 
-# Instantiate HttpRecorder passing the cassette location.
+// Instantiate HttpRecorder passing the cassette location.
 const recorder = new nockUtils.HttpRecorder('cassette.json');
 const startTime = new Date();
 
-# If cassette.json DOES NOT exist it will start recording all http transactions.
-# If cassette.json DOES exist it will playback http requests contained in the cassette. 
+// If cassette.json DOES NOT exist it will start recording all http transactions.
+// If cassette.json DOES exist it will playback http requests contained in the cassette.
 recorder.start();
 
 rest('https://www.comparaonline.com').then((result) => {
-  
-  # This will stop recording and save a new cassette or reset nock.
+
+  // This will stop recording and save a new cassette or reset nock.
   recorder.stop();
-  
+
   const elapsedMilliseconds = new Date() - startTime;
   console.log(elapsedMilliseconds);
 });
@@ -51,12 +51,12 @@ async () => {
 ## Installation
 
 With npm:
-```
-npm install --save-dev nock-utils
+```sh
+$ npm install --save-dev nock-utils
 ```
 With yarn:
-```
-yarn add --dev nock-utils
+```sh
+$ yarn add --dev nock-utils
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ rest('https://www.comparaonline.com').then((result) => {
 });
 ```
 
+## Testing all mocks ran
+
+You can validate all mocks were executed by passing a true to the `nock.stop` method:
+```javascript
+async () => {
+  recorder.start();
+  await rest('https://www.comparaonline.com');
+  recorder.stop(true); // This will throw if the cassette had more mocks than just that request.
+}
+```
+
 ## Installation
 
 With npm:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nock-utils",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Utility tools to simplify recording and playing back http requests during tests",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/recorder/__tests__/.gitignore
+++ b/src/recorder/__tests__/.gitignore
@@ -1,0 +1,1 @@
+test_cassette.json

--- a/src/recorder/__tests__/HttpRecorder.test.ts
+++ b/src/recorder/__tests__/HttpRecorder.test.ts
@@ -175,4 +175,16 @@ describe('Restrict Content by File', () => {
     const cassetteStats = fs.statSync(TEST_CASSETTE_DUPLICATE);
     expect(cassetteStats.size).lt(MAX_DUPLICATE_FILE_SIZE);
   });
+
+  it('fails if all cassettes are required to play and one wasnt used', async () => {
+    const recorder = new HttpRecorder(TEST_CASSETTE);
+    recorder.start();
+    await rest(TEST_URL);
+    await rest(TEST_URL);
+    recorder.stop();
+
+    recorder.start();
+    await rest(TEST_URL);
+    expect(() => recorder.stop(true)).to.throw();
+  });
 });


### PR DESCRIPTION
Now it allows specifying an option on `nock.done` that will cause the statement to throw if mocks are left unused.